### PR TITLE
Added search functionality, fixed issue #10

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -394,43 +394,65 @@ export default function AppSidebar({
 }: React.ComponentProps<typeof Sidebar>) {
   const [title, setTitle] = useState("Developer Utility");
   const [pathname] = useLocation();
+  const [search, setSearch] = useState("");
+
+  // Filter navMain based on search
+  const filteredNav = search.trim()
+    ? navMain
+        .map((category) => {
+          const filteredItems = category.items.filter((util) => {
+            const q = search.toLowerCase();
+            return (
+              util.title.toLowerCase().includes(q) ||
+              category.title.toLowerCase().includes(q)
+            );
+          });
+          return filteredItems.length > 0
+            ? { ...category, items: filteredItems }
+            : undefined;
+        })
+        .filter((cat): cat is typeof navMain[number] => Boolean(cat))
+    : navMain;
 
   return (
     <SidebarProvider className="bg-transparent">
       <Sidebar {...props}>
         <SidebarHeader data-tauri-drag-region className="pt-12">
-          <SearchForm />
+          <SearchForm value={search} onChange={(e) => setSearch(e.target.value)} />
         </SidebarHeader>
         <SidebarContent className="-pr-1 mr-1">
-          {/* We create a SidebarGroup for each parent. */}
-          {navMain.map((category) => (
-            <SidebarGroup key={category.title}>
-              <SidebarGroupLabel className="text-sidebar-foreground">
-                {category.title}
-              </SidebarGroupLabel>
-              <SidebarGroupContent>
-                <SidebarMenu>
-                  {category.items.map((util) => {
-                    const href = `/${category.url}/${util.url}`;
-                    return (
-                      <SidebarMenuItem key={util.title}>
-                        <SidebarMenuButton asChild isActive={pathname === href}>
-                          <Link
-                            href={href}
-                            className="flex items-center gap-2 truncate text-sidebar-foreground"
-                            onClick={() => setTitle(util.title)}
-                          >
-                            <util.icon className="h-4 w-4" />
-                            {util.title}
-                          </Link>
-                        </SidebarMenuButton>
-                      </SidebarMenuItem>
-                    );
-                  })}
-                </SidebarMenu>
-              </SidebarGroupContent>
-            </SidebarGroup>
-          ))}
+          {filteredNav.length === 0 ? (
+            <div className="p-4 text-muted-foreground text-sm">No results found.</div>
+          ) : (
+            filteredNav.map((category) => (
+              <SidebarGroup key={category.title}>
+                <SidebarGroupLabel className="text-sidebar-foreground">
+                  {category.title}
+                </SidebarGroupLabel>
+                <SidebarGroupContent>
+                  <SidebarMenu>
+                    {category.items.map((util) => {
+                      const href = `/${category.url}/${util.url}`;
+                      return (
+                        <SidebarMenuItem key={util.title}>
+                          <SidebarMenuButton asChild isActive={pathname === href}>
+                            <Link
+                              href={href}
+                              className="flex items-center gap-2 truncate text-sidebar-foreground"
+                              onClick={() => setTitle(util.title)}
+                            >
+                              <util.icon className="h-4 w-4" />
+                              {util.title}
+                            </Link>
+                          </SidebarMenuButton>
+                        </SidebarMenuItem>
+                      );
+                    })}
+                  </SidebarMenu>
+                </SidebarGroupContent>
+              </SidebarGroup>
+            ))
+          )}
         </SidebarContent>
         <SidebarRail />
       </Sidebar>

--- a/src/components/sidebar/search-form.tsx
+++ b/src/components/sidebar/search-form.tsx
@@ -22,9 +22,19 @@ import {
   SidebarInput,
 } from "@/components/ui/sidebar"
 
-export function SearchForm({ ...props }: React.ComponentProps<"form">) {
+export interface SearchFormProps {
+  value: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  className?: string
+}
+
+export function SearchForm({ value, onChange, className }: SearchFormProps) {
+  // Prevent form submission from refreshing the page
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+  }
   return (
-    <form {...props}>
+    <form className={className} onSubmit={handleSubmit} autoComplete="off">
       <SidebarGroup className="py-0">
         <SidebarGroupContent className="relative">
           <Label htmlFor="search" className="sr-only">
@@ -32,8 +42,10 @@ export function SearchForm({ ...props }: React.ComponentProps<"form">) {
           </Label>
           <SidebarInput
             id="search"
-            placeholder="Search the docs..."
+            placeholder="Search tools and utilities..."
             className="pl-8"
+            value={value}
+            onChange={onChange}
           />
           <Search className="pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2 opacity-50 select-none" />
         </SidebarGroupContent>


### PR DESCRIPTION
## Implement Tool/Utility Search System in Sidebar  
Closes #10

### Description
- Replaces the incorrect **"Search the docs..."** placeholder with **"Search tools and utilities..."** in the sidebar search input.
- Prevents the search form from refreshing the page on submit.
- Implements a robust, real-time search/filter system for tools and utilities:
  - Filters tools/utilities and categories as the user types.
  - Matches both tool names and category names (case-insensitive).
  - Only displays categories with at least one matching tool.
  - Shows a **“No results found”** message if nothing matches.

### Demo
- Typing in the search box instantly filters the sidebar list.
- No page refresh occurs on `Enter` or input.
- Placeholder is now accurate and user-friendly.

### Notes
- Further enhancements (e.g., fuzzy search, highlighting, searching by description) can be added in future PRs if needed.
