### PR TITLE
fix: add active state to secondary menu items

### DIFF
--- a/packages/frontend/src/components/sidebar/index.tsx
+++ b/packages/frontend/src/components/sidebar/index.tsx
@@ -176,7 +176,10 @@ export default function AppSidebar({
                                       const href = `/${category.key}/${item.key}/${subItem.key}`;
                                       return (
                                         <SidebarMenuSubItem key={subItem.key}>
-                                          <SidebarMenuSubButton asChild>
+                                          <SidebarMenuSubButton 
+                                            asChild
+                                            isActive={pathname === href}
+                                          >
                                             <Link
                                               href={href}
                                               onClick={() => {


### PR DESCRIPTION
Secondary menu items (sub-items) in the sidebar now properly show their active state when selected.

- Added `isActive={pathname === href}` prop to `SidebarMenuSubButton` component
- Fixes issue where TOTP Debugger and other secondary menu items didn't indicate selection
- Follows existing pattern used for regular menu items

Fixes #34

Generated with [Claude Code](https://claude.ai/code)